### PR TITLE
[fix] 홈화면 탭바 검정현상 수정 및 상세화면 모달로 띄우기

### DIFF
--- a/Soulmate/Soulmate.xcodeproj/project.pbxproj
+++ b/Soulmate/Soulmate.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		07497021292E7B26002F607D /* Date+toAge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07497020292E7B26002F607D /* Date+toAge.swift */; };
 		074F3B0B292261EA00D36C89 /* PartnerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074F3B0A292261EA00D36C89 /* PartnerCell.swift */; };
 		07B61AC2292B6C510009BC8A /* DetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B61AC1292B6C510009BC8A /* DetailViewModel.swift */; };
 		07DDDF272924A7C600CB398C /* RegisterBirthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DDDF262924A7C600CB398C /* RegisterBirthView.swift */; };
@@ -137,6 +138,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		07497020292E7B26002F607D /* Date+toAge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+toAge.swift"; sourceTree = "<group>"; };
 		074F3B0A292261EA00D36C89 /* PartnerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartnerCell.swift; sourceTree = "<group>"; };
 		07B61AC1292B6C510009BC8A /* DetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewModel.swift; sourceTree = "<group>"; };
 		07DDDF262924A7C600CB398C /* RegisterBirthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterBirthView.swift; sourceTree = "<group>"; };
@@ -558,6 +560,7 @@
 				6A03B6F12923C00900AC15A6 /* UIFont.swift */,
 				B331CECF292B854500F17AED /* UIImage.swift */,
 				6A34C20D292DBCD400A3E57F /* Date+toString.swift */,
+				07497020292E7B26002F607D /* Date+toAge.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1003,6 +1006,7 @@
 				B331CED0292B854500F17AED /* UIImage.swift in Sources */,
 				6A0041DD2919EADC0042E02F /* HomeCoordinator.swift in Sources */,
 				07EE0F15292C870400E761C4 /* GreetingCell.swift in Sources */,
+				07497021292E7B26002F607D /* Date+toAge.swift in Sources */,
 				6A0041FF2919EE920042E02F /* ModificationViewController.swift in Sources */,
 				6AB6B9B7292D807B00A029BD /* DefaultUserDefaultsRepository.swift in Sources */,
 				6A03B7272923E5E300AC15A6 /* PhoneSignInUseCase.swift in Sources */,

--- a/Soulmate/Soulmate/Presentation/Common/Coordinator/AppCoordinator.swift
+++ b/Soulmate/Soulmate/Presentation/Common/Coordinator/AppCoordinator.swift
@@ -23,8 +23,8 @@ final class AppCoordinator: Coordinator {
     }
     
     func start() {
-        try! Auth.auth().signOut()
-
+        // try! Auth.auth().signOut()
+        
         if let uid = Auth.auth().currentUser?.uid {
             checkRegistration(for: uid)
         }

--- a/Soulmate/Soulmate/Presentation/Common/Coordinator/MainTabCoordinator.swift
+++ b/Soulmate/Soulmate/Presentation/Common/Coordinator/MainTabCoordinator.swift
@@ -67,6 +67,7 @@ final class MainTabCoordinator: NSObject, Coordinator {
         tabBarController.setViewControllers(tabControllers, animated: true)
         tabBarController.selectedIndex = TabBarPage.home.rawValue
         tabBarController.tabBar.isTranslucent = false
+        tabBarController.tabBar.backgroundColor = .systemBackground
         tabBarController.delegate = self
         
         navigationController.viewControllers = [tabBarController]

--- a/Soulmate/Soulmate/Presentation/HomeScene/Coordinator/HomeCoordinator.swift
+++ b/Soulmate/Soulmate/Presentation/HomeScene/Coordinator/HomeCoordinator.swift
@@ -21,6 +21,7 @@ final class HomeCoordinator: Coordinator {
     }
     
     func start() {
+        navigationController.setNavigationBarHidden(true, animated: true)
         showHomeVC()
     }
     
@@ -31,27 +32,27 @@ final class HomeCoordinator: Coordinator {
         navigationController.pushViewController(vc, animated: true)
     }
     
-    func showDetailVC() {
+    func showDetailVC() -> UIViewController {
         // TODO: 정보 전달하기
         //let userInfo = RegisterUserInfo()
         
         // 테스트 데이터
-//        let testData = RegisterUserInfo(
-//            id: "1234",
-//            gender: GenderType.male,
-//            nickName: "테스트",
-//            birthDay: Date(),
-//            height: 175,
-//            mbti: Mbti(innerType: InnerType.i, recognizeType: RecognizeType.n, judgementType: JudgementType.t, lifeStyleType: LifeStyleType.p),
-//            smokingType: SmokingType.often,
-//            drinkingType: DrinkingType.rarely,
-//            aboutMe: "하아라어랴아 러야마얼 야라으마야 라야으라 야을 매야라 으랴 아르 얌로야 ㅡ 라얄오 ㅏ으 랴이라 야므 라야라 만아랴 으마야러 아먀아르 만아라 으망랑 러 ㅁㄴ아랑마라야르 하아 라어랴아러 야마얼야 라으마야 라야으라 야을매야라 으랴 아르 얌로야 ㅡ 라얄오 ㅏ으 랴이라 야므 라야라 만아 랴 으마야러 아먀아르 만아라 으망랑러 ㅁㄴ아랑마라야르 ",
-//            imageList: ["heart", "logo", "Phone", "checkOn"])
-//
-//        let distance = 11
-//
-//        let vm = DetailViewModel(userInfo: testData, distance: distance, coordinator: self)
-//        let vc = DetailViewController(viewModel: vm)
-//        navigationController.pushViewController(vc, animated: true)
+        let testData = RegisterUserInfo(
+            gender: GenderType.male,
+            nickName: "테스트",
+            birthDay: Date(),
+            height: 175,
+            mbti: Mbti(innerType: InnerType.i, recognizeType: RecognizeType.n, judgementType: JudgementType.t, lifeStyleType: LifeStyleType.p),
+            smokingType: SmokingType.often,
+            drinkingType: DrinkingType.rarely,
+            aboutMe: "하아라어랴아 러야마얼 야라으마야 라야으라 야을 매야라 으랴 아르 얌로야 ㅡ 라얄오 ㅏ으 랴이라 야므 라야라 만아랴 으마야러 아먀아르 만아라 으망랑 러 ㅁㄴ아랑마라야르 하아 라어랴아러 야마얼야 라으마야 라야으라 야을매야라 으랴 아르 얌로야 ㅡ 라얄오 ㅏ으 랴이라 야므 라야라 만아 랴 으마야러 아먀아르 만아라 으망랑러 ㅁㄴ아랑마라야르 ",
+            imageList: ["heart", "logo", "Phone", "checkOn"])
+
+        let distance = 11
+
+        let vm = DetailViewModel(userInfo: testData, distance: distance, coordinator: self)
+        let vc = DetailViewController(viewModel: vm)
+        return vc
+        
     }
 }

--- a/Soulmate/Soulmate/Presentation/HomeScene/View/BasicInfoCell.swift
+++ b/Soulmate/Soulmate/Presentation/HomeScene/View/BasicInfoCell.swift
@@ -135,10 +135,10 @@ final class BasicInfoCell: UICollectionViewCell {
         }
     }
     
-    func configure(height: Int, mbti: Mbti, drink: DrinkingType, smoke: SmokingType) {
+    func configure(height: Int, mbti: String, drink: String, smoke: String) {
         heightInput.text = String(height)
-        mbtiInput.text = mbti.toString()
-        drinkInput.text = drink.rawValue
-        smokeInput.text = smoke.rawValue
+        mbtiInput.text = mbti
+        drinkInput.text = drink
+        smokeInput.text = smoke
     }
 }

--- a/Soulmate/Soulmate/Presentation/HomeScene/View/ProfileCell.swift
+++ b/Soulmate/Soulmate/Presentation/HomeScene/View/ProfileCell.swift
@@ -110,15 +110,9 @@ final class ProfileCell: UICollectionViewCell {
         }
     }
     
-    func configure(nickName: String, birthDay: Date, distance: Int) {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy"
-        let year = dateFormatter.string(from: birthDay)
-        let now = dateFormatter.string(from: Date())
-        
-        // TODO: 나이 계산기 만들기
+    func configure(nickName: String, age: Int, distance: Int) {
         partnerName.text = nickName
-        partnerAge.text = String(Int(now)! - Int(year)!)
+        partnerAge.text = String(age)
         partnerDistance.text = String(distance) + "km"
     }
 }

--- a/Soulmate/Soulmate/Presentation/HomeScene/ViewController/DetailViewController.swift
+++ b/Soulmate/Soulmate/Presentation/HomeScene/ViewController/DetailViewController.swift
@@ -12,6 +12,15 @@ import SnapKit
 
 final class DetailViewController: UIViewController {
     private let pagingInfoSubject = PassthroughSubject<Int, Never>()
+    private let photosPublisher = PassthroughSubject<[String], Never>()
+    private let nicknamePublisher = PassthroughSubject<String, Never>()
+    private let agePublisher = PassthroughSubject<Date, Never>()
+    private let distancePublisher = PassthroughSubject<Int, Never>()
+    private let greetingMessagePublisher = PassthroughSubject<String, Never>()
+    private let heightPublisher = PassthroughSubject<Int, Never>()
+    private let mbtiPublisher = PassthroughSubject<Mbti, Never>()
+    private let drinkingPublisher = PassthroughSubject<DrinkingType, Never>()
+    private let smokingPublisher = PassthroughSubject<SmokingType, Never>()
 
     private var viewModel: DetailViewModel?
     private var cancellables = Set<AnyCancellable>()
@@ -62,14 +71,34 @@ final class DetailViewController: UIViewController {
         configureLayout()
         
         bind()
-
     }
 }
 
 // MARK: - configure
 private extension DetailViewController {
     private func bind() {
-
+        let _ = viewModel?.transform(input: DetailViewModel.Input(
+            setPhotos: photosPublisher.eraseToAnyPublisher(),
+            setNickname: nicknamePublisher.eraseToAnyPublisher(),
+            setAge: agePublisher.eraseToAnyPublisher(),
+            setDistance: distancePublisher.eraseToAnyPublisher(),
+            setGreetingMessage: greetingMessagePublisher.eraseToAnyPublisher(),
+            setHeight: heightPublisher.eraseToAnyPublisher(),
+            setMbti: mbtiPublisher.eraseToAnyPublisher(),
+            setDrinking: drinkingPublisher.eraseToAnyPublisher(),
+            setSmoking: smokingPublisher.eraseToAnyPublisher(),
+            didTouchedTalkButton: applyButton.tapPublisher()))
+        
+        photosPublisher.send(viewModel?.userInfo?.imageList ?? [])
+        nicknamePublisher.send(viewModel?.userInfo?.nickName ?? "")
+        agePublisher.send(viewModel?.userInfo?.birthDay ?? Date())
+        distancePublisher.send(viewModel?.distance ?? 0)
+        greetingMessagePublisher.send(viewModel?.userInfo?.aboutMe ?? "")
+        heightPublisher.send(viewModel?.userInfo?.height ?? 0)
+        mbtiPublisher.send(viewModel?.userInfo?.mbti ?? Mbti(innerType: .i, recognizeType: .n, judgementType: .t, lifeStyleType: .p))
+        drinkingPublisher.send(viewModel?.userInfo?.drinkingType ?? DrinkingType.none)
+        smokingPublisher.send(viewModel?.userInfo?.smokingType ?? SmokingType.none)
+        
     }
     
     private func configureView() {
@@ -99,7 +128,7 @@ extension DetailViewController: UICollectionViewDataSource, UICollectionViewDele
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if section == 0 {
-            return viewModel?.userInfo.imageList?.count ?? 1
+            return viewModel?.photos?.count ?? 1
         } else {
             return 1
         }
@@ -111,31 +140,31 @@ extension DetailViewController: UICollectionViewDataSource, UICollectionViewDele
             guard let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: "PhotoCell",
                 for: indexPath) as? PhotoCell else { return PhotoCell() }
-            cell.loadImage(image: viewModel?.userInfo.imageList?[indexPath.item] ?? "")
+            cell.loadImage(image: viewModel?.photos?[indexPath.item] ?? "")
             return cell
             
         case 1:
             guard let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: "ProfileCell",
                 for: indexPath) as? ProfileCell else { return ProfileCell() }
-            cell.configure(nickName: viewModel?.userInfo.nickName ?? "", birthDay: viewModel?.userInfo.birthDay ?? Date(), distance: viewModel?.distance ?? 0)
+            cell.configure(nickName: viewModel?.nickname ?? "", age: viewModel?.age ?? 0, distance: viewModel?.distance ?? 0)
             return cell
             
         case 2:
             guard let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: "GreetingCell",
                 for: indexPath) as? GreetingCell else { return GreetingCell() }
-            cell.configure(message: viewModel?.userInfo.aboutMe ?? "")
+            cell.configure(message: viewModel?.greetingMessage ?? "[등록된 인사말이 없습니다🥲]")
             return cell
             
         case 3:
             guard let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: "BasicInfoCell",
                 for: indexPath) as? BasicInfoCell,
-                  let height = viewModel?.userInfo.height,
-                  let mbti = viewModel?.userInfo.mbti,
-                  let drink = viewModel?.userInfo.drinkingType,
-                  let smoke = viewModel?.userInfo.smokingType else { return BasicInfoCell() }
+                  let height = viewModel?.height,
+                  let mbti = viewModel?.mbti,
+                  let drink = viewModel?.drinking,
+                  let smoke = viewModel?.smoking else { return BasicInfoCell() }
             cell.configure(height: height, mbti: mbti, drink: drink, smoke: smoke)
             return cell
             

--- a/Soulmate/Soulmate/Presentation/HomeScene/ViewController/HomeViewController.swift
+++ b/Soulmate/Soulmate/Presentation/HomeScene/ViewController/HomeViewController.swift
@@ -129,13 +129,13 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
         
         recommendAgainButton.snp.makeConstraints {
             $0.left.right.equalToSuperview().inset(20)
-            $0.bottom.equalToSuperview().inset(40)
+            $0.bottom.equalToSuperview().inset(20)
             $0.height.equalTo(54)
         }
         
         collectionView.snp.makeConstraints {
-            $0.top.equalTo(logo.snp.bottom).offset(29)
-            $0.bottom.equalTo(recommendAgainButton.snp.top).offset(-36)
+            $0.top.equalTo(logo.snp.bottom).offset(20)
+            $0.bottom.equalTo(recommendAgainButton.snp.top).offset(-20)
             $0.centerX.equalToSuperview()
             $0.width.equalToSuperview().inset(20)
         }
@@ -155,7 +155,8 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        viewModel?.coordinator?.showDetailVC()
+        guard let vc = viewModel?.coordinator?.showDetailVC() else { return }
+        self.present(vc, animated: true)
     }
     
 }

--- a/Soulmate/Soulmate/Presentation/HomeScene/ViewModel/DetailViewModel.swift
+++ b/Soulmate/Soulmate/Presentation/HomeScene/ViewModel/DetailViewModel.swift
@@ -6,28 +6,103 @@
 //
 
 import Foundation
+import Combine
 
 final class DetailViewModel {
-    let userInfo: RegisterUserInfo
-    let distance: Int
-
     private weak var coordinator: HomeCoordinator?
+    var cancellables = Set<AnyCancellable>()
+    var userInfo: RegisterUserInfo?
+    
+    @Published var photos: [String]?
+    @Published var nickname: String?
+    @Published var age: Int?
+    @Published var distance: Int?
+    @Published var greetingMessage: String?
+    @Published var height: Int?
+    @Published var mbti: String?
+    @Published var drinking: String?
+    @Published var smoking: String?
+    
+    func talkButtonTouched() {
+        
+    }
     
     init(userInfo: RegisterUserInfo, distance: Int, coordinator: HomeCoordinator) {
+        self.coordinator = coordinator
         self.userInfo = userInfo
         self.distance = distance
-        self.coordinator = coordinator
     }
 
-    
 }
 
 extension DetailViewModel {
-    struct Input { }
-    
+    struct Input {
+        var setPhotos: AnyPublisher<[String], Never>
+        var setNickname: AnyPublisher<String, Never>
+        var setAge: AnyPublisher<Date, Never>
+        var setDistance: AnyPublisher<Int, Never>
+        var setGreetingMessage: AnyPublisher<String, Never>
+        var setHeight: AnyPublisher<Int, Never>
+        var setMbti: AnyPublisher<Mbti, Never>
+        var setDrinking: AnyPublisher<DrinkingType, Never>
+        var setSmoking: AnyPublisher<SmokingType, Never>
+        var didTouchedTalkButton: AnyPublisher<Void, Never>
+    }
+
     struct Output { }
     
     func transform(input: Input) -> Output {
+        input.setPhotos
+            .compactMap { $0 }
+            .assign(to: \.photos, on: self)
+            .store(in: &cancellables)
+        
+        input.setNickname
+            .compactMap { $0 }
+            .assign(to: \.nickname, on: self)
+            .store(in: &cancellables)
+        
+        input.setAge
+            .compactMap { $0.toAge() }
+            .assign(to: \.age, on: self)
+            .store(in: &cancellables)
+        
+        input.setDistance
+            .compactMap { $0 }
+            .assign(to: \.distance, on: self)
+            .store(in: &cancellables)
+        
+        input.setGreetingMessage
+            .compactMap { $0 }
+            .assign(to: \.greetingMessage, on: self)
+            .store(in: &cancellables)
+        
+        input.setHeight
+            .compactMap { $0 }
+            .assign(to: \.height, on: self)
+            .store(in: &cancellables)
+        
+        input.setMbti
+            .compactMap { $0.toString() }
+            .assign(to: \.mbti, on: self)
+            .store(in: &cancellables)
+        
+        input.setDrinking
+            .compactMap { $0.rawValue }
+            .assign(to: \.drinking, on: self)
+            .store(in: &cancellables)
+        
+        input.setSmoking
+            .compactMap { $0.rawValue }
+            .assign(to: \.smoking, on: self)
+            .store(in: &cancellables)
+        
+        input.didTouchedTalkButton
+            .sink { [weak self] _ in
+                self?.talkButtonTouched()
+            }
+            .store(in: &cancellables)
+        
         return Output()
     }
 }

--- a/Soulmate/Soulmate/Util/Extension/Date+toAge.swift
+++ b/Soulmate/Soulmate/Util/Extension/Date+toAge.swift
@@ -1,0 +1,18 @@
+//
+//  Date+toAge.swift
+//  Soulmate
+//
+//  Created by termblur on 2022/11/24.
+//
+
+import Foundation
+
+extension Date { // 만나이 계산기
+    func toAge() -> Int {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+
+        return Calendar.current.dateComponents([.year], from: self, to: Date()).year ?? 0
+    }
+}

--- a/Soulmate/Soulmate/Util/Extension/Date+toAge.swift
+++ b/Soulmate/Soulmate/Util/Extension/Date+toAge.swift
@@ -9,10 +9,6 @@ import Foundation
 
 extension Date { // 만나이 계산기
     func toAge() -> Int {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .none
-
         return Calendar.current.dateComponents([.year], from: self, to: Date()).year ?? 0
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가 🔨
- [ ] 버그 수정 🐞
- [x] 리팩토링 🚧
- [ ] 문서 📄
- [ ] 코드 스타일 😎
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [x] 기타 사소한 수정 🎸
- [ ] 테스트 🔍

### 변경 내용
- https://github.com/boostcampwm-2022/iOS07-Soulmate/issues/94
- 홈화면 탭바 검정현상 수정 
- 상세화면 모달로 띄우기
- Date+toAge.swift : 만 나이 계산기 Extension 추가 (Date -> Int)

### 스크린샷
![홈,상세](https://user-images.githubusercontent.com/69361087/203557841-fdaf5248-6a5e-471e-aa92-57ef2e8c8be8.gif)

---

![스크린샷 2022-11-24 오전 1 29 09](https://user-images.githubusercontent.com/69361087/203599109-4f871ad8-ae90-4526-9961-855e733c3864.png)



